### PR TITLE
feat: add /version endpoint with build metadata

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -31,7 +31,8 @@ def home():
             "GET /": "Cette page",
             "GET /health": "Health check",
             "POST /calculate": "Calculatrice (envoyer JSON avec a, b, operation)",
-            "GET /info": "Informations sur l'environnement"
+            "GET /info": "Informations sur l'environnement",
+            "GET /version": "Build metadata (git SHA, build date)"
         }
     }), 200
 
@@ -86,6 +87,16 @@ def info():
         "python_version": os.sys.version,
         "api_version": API_VERSION,
         "deployed_at": datetime.datetime.utcnow().isoformat()
+    }), 200
+
+
+@app.route("/version", methods=["GET"])
+def version():
+    return jsonify({
+        "version": API_VERSION,
+        "git_sha": os.getenv("GIT_SHA", "unknown"),
+        "build_date": os.getenv("BUILD_DATE", "unknown"),
+        "environment": os.getenv("FLASK_ENV", "production")
     }), 200
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -167,3 +167,25 @@ class TestInfo:
         response = client.get("/info")
         data = response.get_json()
         assert "python_version" in data
+
+
+# =============================================================================
+# Tests de la route GET /version
+# =============================================================================
+class TestVersion:
+    def test_version_returns_200(self, client):
+        """La route version doit retourner 200."""
+        response = client.get("/version")
+        assert response.status_code == 200
+
+    def test_version_contains_version(self, client):
+        """La reponse doit contenir la version."""
+        response = client.get("/version")
+        data = response.get_json()
+        assert "version" in data
+
+    def test_version_contains_git_sha(self, client):
+        """La reponse doit contenir le git SHA."""
+        response = client.get("/version")
+        data = response.get_json()
+        assert "git_sha" in data


### PR DESCRIPTION
## Summary
- Added `GET /version` endpoint returning git SHA, build date, and environment
- Added 3 unit tests for the new endpoint
- Updated home route to list the new endpoint

## Related
Closes #2

## Test plan
- [x] `GET /version` returns 200 with correct fields
- [x] Response includes `version`, `git_sha`, `build_date`
- [x] All existing tests still pass